### PR TITLE
email.header expects str not unicode

### DIFF
--- a/imapy/email_message.py
+++ b/imapy/email_message.py
@@ -149,7 +149,7 @@ class EmailMessage(CaseInsensitiveDict):
                     # rare cases when we get decoding error
                     except AssertionError:
                         data = None
-                    attachment_fname = decode_header(part.get_filename())
+                    attachment_fname = decode_header(part.get_filename().encode('utf8'))
                     filename = self.clean_value(
                         attachment_fname[0][0], attachment_fname[0][1]
                     )


### PR DESCRIPTION
```
  File "D:\dev\Python27\lib\site-packages\imapy\imap.py", line 261, in email
    emails = self.emails(sequence_number, sequence_number)
  File "D:\dev\Python27\lib\site-packages\imapy\imap.py", line 34, in wrapper
    return func(*args, **kwargs)
  File "D:\dev\Python27\lib\site-packages\imapy\imap.py", line 279, in emails
    return self._get_emails_by_sequence(args[0], args[1])
  File "D:\dev\Python27\lib\site-packages\imapy\imap.py", line 345, in _get_emails_by_sequence
    return self._fetch_emails_info(uids)
  File "D:\dev\Python27\lib\site-packages\imapy\imap.py", line 34, in wrapper
    return func(*args, **kwargs)
  File "D:\dev\Python27\lib\site-packages\imapy\imap.py", line 385, in _fetch_emails_info
    email_obj=email_obj, imap_obj=self)
  File "D:\dev\Python27\lib\site-packages\imapy\email_message.py", line 43, in __init__
    self.parse()
  File "D:\dev\Python27\lib\site-packages\imapy\email_message.py", line 152, in parse
    attachment_fname = decode_header(part.get_filename())
  File "D:\dev\Python27\lib\email\header.py", line 73, in decode_header
    header = str(header)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2026' in position 47: ordinal not in range(128)
```
