### PR TITLE
Added support to only retrieve a list of UID:s, not their content

### DIFF
--- a/imapy/email_message.py
+++ b/imapy/email_message.py
@@ -149,7 +149,7 @@ class EmailMessage(CaseInsensitiveDict):
                     # rare cases when we get decoding error
                     except AssertionError:
                         data = None
-                    attachment_fname = decode_header(part.get_filename())
+                    attachment_fname = decode_header(part.get_filename() or '')
                     filename = self.clean_value(
                         attachment_fname[0][0], attachment_fname[0][1]
                     )


### PR DESCRIPTION
Feel free to close this if you deem it not fit for inclusion, I use imapy in a parallel fashion which means I first need to get a list of IDS and then I distribute them evenly across workers. However, right now `emails()` fetches the email's as well. This introduces a simple keyword argument called `ids_only` which when called only return the list of UIDs.

Usage:
`print(box.folder('INBOX').emails(ids_only=True))`