### PR TITLE
Fixes several mail parsing and folder list bugs

### DIFF
--- a/imapy/email_message.py
+++ b/imapy/email_message.py
@@ -149,7 +149,7 @@ class EmailMessage(CaseInsensitiveDict):
                     # rare cases when we get decoding error
                     except AssertionError:
                         data = None
-                    attachment_fname = decode_header(part.get_filename())
+                    attachment_fname = decode_header(part.get_filename() or '')
                     filename = self.clean_value(
                         attachment_fname[0][0], attachment_fname[0][1]
                     )
@@ -167,7 +167,8 @@ class EmailMessage(CaseInsensitiveDict):
                 msg_subject[0][0], msg_subject[0][1])
         # from
         # cleanup header
-        from_header_cleaned = re.sub('[\n\r\t]+', ' ', self.email_obj['from'])
+        from_header_cleaned = re.sub('[\n\r\t]+', ' ',
+                                     self.email_obj['from'] or '')
         msg_from = decode_header(from_header_cleaned)
         msg_txt = ''
         for part in msg_from:

--- a/imapy/mail_folder.py
+++ b/imapy/mail_folder.py
@@ -66,6 +66,13 @@ class MailFolder():
         max_depth = 0
         for raw_folder in raw_folders:
             # get name attributes, hierarchy delimiter, name
+            if not raw_folder:
+                continue
+
+            if isinstance(raw_folder, tuple):
+                len_suffix = '{%d}' % len(raw_folder[1])
+                raw_folder = raw_folder[0][:-len(len_suffix)] + raw_folder[1]
+
             # decode folder name
             raw_folder = utils.utf7_to_unicode(raw_folder)
             match = self.folder_parts.match(raw_folder)
@@ -92,12 +99,16 @@ class MailFolder():
             # box attributes
             attributes = match.group('attributes').split()
             attributes = [a.lstrip('\\') for a in attributes]
+
             # separator
-            self.separator = utils.to_str(match.group('separator'))
+            self.separator = utils.to_unescaped_str(match.group('separator'))
+
             # full name (unique identifier for mailbox)
             full_name = match.group('name')
+
             # full name with no path part
             name = full_name.split(self.separator).pop()
+
             # parent's name
             parent_name = False
             if full_name.count(self.separator):
@@ -105,6 +116,7 @@ class MailFolder():
                 parent_name = self.separator.join(
                     [i for i in parent_parts[:-1]]
                 )
+
             # depth
             depth = full_name.count(self.separator)
             if depth > max_depth:

--- a/imapy/utils.py
+++ b/imapy/utils.py
@@ -29,6 +29,10 @@ if six.PY2:
         """Convert to UTF-8"""
         return text.encode('utf-8')
 
+    def to_unescaped_str(text):
+        """Convert escaped string to string"""
+        return text.decode('string_escape')
+
     def b_to_str(text):
         """Convert to string"""
         return text
@@ -53,6 +57,10 @@ elif six.PY3:
     def to_str(text):
         """Convert to UTF-8"""
         return text
+
+    def to_unescaped_str(text):
+        """Convert escaped string to string"""
+        return text.encode('utf-8').decode('unicode_escape')
 
     def b_to_str(text):
         """Convert to string"""


### PR DESCRIPTION
Hello, I couldn't tell whether this project is still maintained or not, but figured I would submit this PR anyway just in case -- and for others to find easily if they run into the same bugs.

While running this over my inbox folder at work with nearly 10k messages for the last few years, I found a few bugs in the way imapy parses some folder list data and message data.

I'm only partially confident in the way I've handled the fixes around servers that use a folder delimiter of `\`. While it now successfully builds the folder tree, moving messages into a non-root (child) folder still does not work. I'm not exactly sure why yet, but it seems related to the `\` delimiter -- just didn't have ample time to finish figuring out why that is.

That being said, it would be great if you or others could test these changes with other imap servers, as I don't have a lot I can test against at the moment.

Thank you!

Summary of fixes from commit msg:
```
* Don't explode if a MIME attachment does not specify a filename.
  Default to a blank string instead of None.

* Don't explode if a 'From' header is not given. Default to a blank
  string instead of None.

* Properly handle an IMAP server sending a long-form folder name
  by specifying its length followed by the actual name separately.

  imaplib returns this as a tuple of two strings, rather than a single
  string. It's also followed by a blank string for the next element
  in the folder list, which needs skipping (see next bullet).
  For example:
    normal:    '(\\HasNoChildren) "\\\\" dev.github'
    long form: ('(\\HasNoChildren) "\\\\" {11}', 'lists\\nanog'),
               '',

* Don't explode if the server sends a blank value where we might
  normally expect to see a folder name (happens when receiving a
  folder name in long form - see prior bullet).

* Properly handle folder hierarchy delimiters of '\', which appear on
  each folder's delimiter field as b'\\\\', and need to be unescaped
  to b'\\', which is how they appear in the actual folder name.
```